### PR TITLE
Adds support for custom levelup backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,39 @@ inject different level implementations (browser, leveldb, etc) into your tests.
 
 Create a fresh db, with out refering to any fs or dom specifics,
 so that the same test can be used in the server or the browser!
+
 ``` js
-
 var level = require('level-test')()
-
-var db = level('foo', {encoding: 'json'}) 
+var db = level('foo', { encoding: 'json' })
 ```
 
 ## In Memory Example
 
 ``` js
-
 var level = require('level-test')( { mem: true })
-
-var db = level('foo', {encoding: 'json'}) 
+var db = level('foo', { encoding: 'json' })
 ```
 
-use whatever test framework you like!
+Use whatever test framework you like!
 
-## options
-currently supported options:
+## Custom Backends
+
+A custom backend for `levelup` can be provided via the options object:
+
+```js
+var hyper = require('leveldown-hyper')
+var level = require('level-test')( { db: hyper })
+var db = level('foo', { encoding: 'json' })
+```
+
+## Options
+
+Currently supported options:
 
 ``` js
 level(name, {
-  clean: false //do not delete database (defaults to true)
+  clean: false, // do not delete database (defaults to true)
+  db: require('leveldown-hyper') // optional, defaults to leveldown
 })
 
 ```

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function disk (opts) {
     var dir = path.join(tmpdir, name)
     if(_opts.clean !== false)
       rimraf.sync(dir)
-    _opts.db = leveldown
+    _opts.db = _opts.db || leveldown
     return levelup(dir, _opts, cb)
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "leveldown": "~0.10.2"
   },
   "devDependencies": {
-    "tape": "~3.0.0"
+    "tape": "~3.0.0",
+    "leveldown-hyper": "~0.10.2"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var level = require('../')()
 var test = require('tape')
+var hyper = require('leveldown-hyper')
 
 test('simple', function (t) {
   var db = level('level-test', {encoding: 'json'})
@@ -15,7 +16,6 @@ test('simple', function (t) {
     })
   })
 })
-
 
 test('default name', function (t) {
   var db = level()
@@ -36,6 +36,23 @@ test('options (valueEncoding: json)', function (t) {
     db.get(key, function (err, _value) {
       t.deepEqual(_value, value)
       t.end()
+    })
+  })
+})
+
+test('custom backend for levelup', function (t) {
+  var db = level('level-test3', { db: hyper })
+  var key = 'foo'
+  var value = 'bar'
+
+  db.put(key, value, function (err) {
+    t.notOk(err)
+    db.get(key, function (err, _value) {
+      t.equal(_value, value)
+      db.db.liveBackup('baz', function (err) {
+        t.notOk(err, 'liveBackup worked')
+        t.end()
+      })
     })
   })
 })


### PR DESCRIPTION
This enables the user to provide a custom backend for `levelup`, either through `_opts.db` or `opts.db`